### PR TITLE
Removing "dflags: ['-unittest']"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,4 @@
 	"authors": ["Gary Willoughby"],
 	"copyright": "Copyright (c) 2013 Gary Willoughby",
 	"license": "MIT",
-	"dflags": ["-unittest"],
 }


### PR DESCRIPTION
According to the output from DUB:

```
The following compiler flags have been specified in the package description
file. They are handled by DUB and direct use in packages is discouraged.
Alternatively, you can set the DFLAGS environment variable to pass custom flags
to the compiler, or use one of the suggestions below:

-unittest: Call dub with --build=unittest

```
