### PR TITLE
Throw exceptions from mocked methods.

### DIFF
--- a/source/dunit/mockable.d
+++ b/source/dunit/mockable.d
@@ -493,3 +493,21 @@ unittest
 	mock.method5(10).assertEqual(20);
 	mock.method6(10);
 }
+
+unittest
+{
+	import dunit.toolkit;
+
+	static class T
+	{
+		public int method1(int param) nothrow { assert(false, "thrown from test"); };
+		public void method2(int param) { throw new Exception("thrown from test"); };
+
+		mixin Mockable!T;
+	}
+
+	auto mock = T.getMock();
+
+	mock.method1(10).assertThrow!Throwable("thrown from test");
+	mock.method2(10).assertThrow!Exception("thrown from test");
+}

--- a/source/dunit/reflection.d
+++ b/source/dunit/reflection.d
@@ -481,9 +481,11 @@ private template MethodBody(bool hasParent, func...)
 		code ~= "\t}\n";
 		code ~= "\tcatch(Exception ex)\n";
 		code ~= "\t{\n";
-		static if (isMethodNothrow!(func)) {
+		static if (isMethodNothrow!(func)) 
+		{
 			code ~= "\t\tassert(false, ex.msg);\n";
-		} else {
+		} else 
+		{
 			code ~= "\t\tthrow ex;\n";
 		}
 		code ~= "\t}\n";


### PR DESCRIPTION
I noticed an issue when i tried to test the error-behaviour of one of my classes
Method A of my class calls Method B of the same class. I mocked method B so that it throws an exception in order to verify that method A behaves correctly in the case of an error. 
However: the exceptions thrown in the mocked method are caught by dunit itself. This made it impossible to unit-test the error-behaviour.
I changed the code so that exceptions are rethrown if the mocked method is not nothrow. If the mocked method is nothrow, the code behaves as before and catches the exception and throws an assertion-error.
